### PR TITLE
feat(settings): modularize and refactor settings command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn.lock
 
 # Ignore coverage if present
 coverage/
+
+# data - settings.json
+data

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,4 +1,4 @@
-import type { RESTPostAPIApplicationCommandsJSONBody, CommandInteraction } from 'discord.js';
+import type { RESTPostAPIApplicationCommandsJSONBody, ChatInputCommandInteraction } from 'discord.js';
 import { z } from 'zod';
 import type { StructurePredicate } from '../util/loaders.js';
 
@@ -15,7 +15,7 @@ export type Command = {
 	 *
 	 * @param interaction - The interaction of the command
 	 */
-	execute(interaction: CommandInteraction): Promise<void> | void;
+	execute(interaction: ChatInputCommandInteraction): Promise<void> | void;
 };
 
 /**

--- a/src/commands/utility/settings.ts
+++ b/src/commands/utility/settings.ts
@@ -1,48 +1,144 @@
 import { ApplicationCommandOptionType } from 'discord.js';
 import type { Command } from '../index.js';
+import { resolveTarget } from '../../util/resolveTarget.js';
+import { readSettings, writeSettings } from '../../util/settingsStore.js';
 
 export default {
 	data: {
 		name: 'settings',
-		description: "Used to modify the bot's settings .",
+		description: "Used to modify the bot's settings.",
 		options: [
 			{
-				name: 'access',
-				description: 'Manage access roles',
-				type: ApplicationCommandOptionType.SubcommandGroup,
-				options: [
+				name: 'category',
+				description: 'Setting category to modify',
+				type: ApplicationCommandOptionType.String,
+				required: true,
+				choices: [
 					{
-						name: 'add',
-						description: 'Add a role to access',
-						type: ApplicationCommandOptionType.Subcommand,
-						options: [
-							{
-								name: 'role',
-								description: 'Role to add',
-								type: ApplicationCommandOptionType.Role,
-								required: true,
-							},
-						],
+						name: 'Access Permissions',
+						value: 'access',
 					},
 					{
-						name: 'remove',
-						description: 'Remove a role from access',
-						type: ApplicationCommandOptionType.Subcommand,
-						options: [
-							{
-								name: 'role',
-								description: 'Role to remove',
-								type: ApplicationCommandOptionType.Role,
-								required: true,
-							},
-						],
+						name: 'Bot Prompt',
+						value: 'prompt',
 					},
 				],
+			},
+			{
+				name: 'action',
+				description: 'Action to perform',
+				type: ApplicationCommandOptionType.String,
+				required: true,
+				choices: [
+					{
+						name: 'View',
+						value: 'view',
+					},
+					{
+						name: 'Add',
+						value: 'add',
+					},
+					{
+						name: 'Remove',
+						value: 'remove',
+					},
+					{
+						name: 'Set',
+						value: 'set',
+					},
+					{
+						name: 'Reset',
+						value: 'reset',
+					},
+				],
+			},
+			{
+				name: 'target',
+				description: 'Target identifier or value (ID, mention, tag, role, or free text)',
+				type: ApplicationCommandOptionType.String,
+				required: false,
 			},
 		],
 	},
 	async execute(interaction) {
-		// make it actually work
-		await interaction.reply(`This command was run by ${interaction.user.username}.`);
+		const category = interaction.options.getString('category', true);
+		const action = interaction.options.getString('action', true);
+		const target = interaction.options.getString('target');
+
+		const settings = await readSettings();
+
+		if (category === 'access') {
+			if (!['add', 'remove', 'view'].includes(action)) {
+				await interaction.reply('Access permissions only support **add**, **remove**, and **view** actions.');
+				return;
+			}
+
+			if (['add', 'remove'].includes(action) && !target) {
+				await interaction.reply('Target is required for access permission changes.');
+				return;
+			}
+
+			if (action === 'add') {
+				const resolved = await resolveTarget(interaction.guild, target!);
+				const display =
+					resolved.kind === 'member'
+						? `${resolved.member.user.tag}`
+						: resolved.kind === 'role'
+							? `@${resolved.role.name}`
+							: target;
+
+				settings.access = settings.access ?? [];
+				if (!settings.access.includes(target!)) {
+					settings.access.push(target!);
+					await writeSettings(settings);
+					await interaction.reply(`Added ${display} to access list.`);
+				} else {
+					await interaction.reply(`${display} is already in the access list.`);
+				}
+			} else if (action === 'remove') {
+				settings.access = settings.access ?? [];
+				const resolved = await resolveTarget(interaction.guild, target!);
+				const display =
+					resolved.kind === 'member'
+						? `${resolved.member.user.tag}`
+						: resolved.kind === 'role'
+							? `@${resolved.role.name}`
+							: target;
+
+				const idx = settings.access.indexOf(target!);
+				if (idx !== -1) {
+					settings.access.splice(idx, 1);
+					await writeSettings(settings);
+					await interaction.reply(`Removed ${display} from access list.`);
+				} else {
+					await interaction.reply(`${display} was not found in the access list.`);
+				}
+			} else if (action === 'view') {
+				const list = settings.access ?? [];
+				if (list.length === 0) await interaction.reply('Access list is empty.');
+				else await interaction.reply(`Access list:\n${list.join('\n')}`);
+			}
+		} else if (category === 'prompt') {
+			if (!['set', 'reset', 'view'].includes(action)) {
+				await interaction.reply('Bot prompt only supports **set**, **reset**, and **view** actions.');
+				return;
+			}
+
+			if (action === 'set') {
+				if (!target) {
+					await interaction.reply('Value is required when setting the prompt.');
+					return;
+				}
+				settings.prompt = target;
+				await writeSettings(settings);
+				await interaction.reply(`Bot prompt set to: "${target}"`);
+			} else if (action === 'reset') {
+				delete settings.prompt;
+				await writeSettings(settings);
+				await interaction.reply('Bot prompt reset to default.');
+			} else if (action === 'view') {
+				await interaction.reply(`Current prompt: ${settings.prompt ?? '*not set*'}`);
+			}
+		}
 	},
 } satisfies Command;

--- a/src/commands/utility/settings.ts
+++ b/src/commands/utility/settings.ts
@@ -1,7 +1,7 @@
 import { ApplicationCommandOptionType } from 'discord.js';
 import type { Command } from '../index.js';
-import { resolveTarget } from '../../util/resolveTarget.js';
-import { readSettings, writeSettings } from '../../util/settingsStore.js';
+import { readSettings } from '../../util/settingsStore.js';
+import { getAllCategories, getModule } from './settings/registry.js';
 
 export default {
 	data: {
@@ -13,44 +13,14 @@ export default {
 				description: 'Setting category to modify',
 				type: ApplicationCommandOptionType.String,
 				required: true,
-				choices: [
-					{
-						name: 'Access Permissions',
-						value: 'access',
-					},
-					{
-						name: 'Bot Prompt',
-						value: 'prompt',
-					},
-				],
+				choices: getAllCategories(),
 			},
 			{
 				name: 'action',
 				description: 'Action to perform',
 				type: ApplicationCommandOptionType.String,
 				required: true,
-				choices: [
-					{
-						name: 'View',
-						value: 'view',
-					},
-					{
-						name: 'Add',
-						value: 'add',
-					},
-					{
-						name: 'Remove',
-						value: 'remove',
-					},
-					{
-						name: 'Set',
-						value: 'set',
-					},
-					{
-						name: 'Reset',
-						value: 'reset',
-					},
-				],
+				autocomplete: true,
 			},
 			{
 				name: 'target',
@@ -66,79 +36,19 @@ export default {
 		const target = interaction.options.getString('target');
 
 		const settings = await readSettings();
+		const module = getModule(category);
 
-		if (category === 'access') {
-			if (!['add', 'remove', 'view'].includes(action)) {
-				await interaction.reply('Access permissions only support **add**, **remove**, and **view** actions.');
-				return;
-			}
+		if (!module) {
+			await interaction.reply(`Unknown settings category: ${category}`);
+			return;
+		}
 
-			if (['add', 'remove'].includes(action) && !target) {
-				await interaction.reply('Target is required for access permission changes.');
-				return;
-			}
-
-			if (action === 'add') {
-				const resolved = await resolveTarget(interaction.guild, target!);
-				const display =
-					resolved.kind === 'member'
-						? `${resolved.member.user.tag}`
-						: resolved.kind === 'role'
-							? `@${resolved.role.name}`
-							: target;
-
-				settings.access = settings.access ?? [];
-				if (!settings.access.includes(target!)) {
-					settings.access.push(target!);
-					await writeSettings(settings);
-					await interaction.reply(`Added ${display} to access list.`);
-				} else {
-					await interaction.reply(`${display} is already in the access list.`);
-				}
-			} else if (action === 'remove') {
-				settings.access = settings.access ?? [];
-				const resolved = await resolveTarget(interaction.guild, target!);
-				const display =
-					resolved.kind === 'member'
-						? `${resolved.member.user.tag}`
-						: resolved.kind === 'role'
-							? `@${resolved.role.name}`
-							: target;
-
-				const idx = settings.access.indexOf(target!);
-				if (idx !== -1) {
-					settings.access.splice(idx, 1);
-					await writeSettings(settings);
-					await interaction.reply(`Removed ${display} from access list.`);
-				} else {
-					await interaction.reply(`${display} was not found in the access list.`);
-				}
-			} else if (action === 'view') {
-				const list = settings.access ?? [];
-				if (list.length === 0) await interaction.reply('Access list is empty.');
-				else await interaction.reply(`Access list:\n${list.join('\n')}`);
-			}
-		} else if (category === 'prompt') {
-			if (!['set', 'reset', 'view'].includes(action)) {
-				await interaction.reply('Bot prompt only supports **set**, **reset**, and **view** actions.');
-				return;
-			}
-
-			if (action === 'set') {
-				if (!target) {
-					await interaction.reply('Value is required when setting the prompt.');
-					return;
-				}
-				settings.prompt = target;
-				await writeSettings(settings);
-				await interaction.reply(`Bot prompt set to: "${target}"`);
-			} else if (action === 'reset') {
-				delete settings.prompt;
-				await writeSettings(settings);
-				await interaction.reply('Bot prompt reset to default.');
-			} else if (action === 'view') {
-				await interaction.reply(`Current prompt: ${settings.prompt ?? '*not set*'}`);
-			}
+		try {
+			const result = await module.execute(interaction, action, target, settings);
+			await interaction.reply(result.reply);
+		} catch (error) {
+			console.error('Settings command error:', error);
+			await interaction.reply('An error occurred while processing the settings command.');
 		}
 	},
 } satisfies Command;

--- a/src/commands/utility/settings/accessModule.ts
+++ b/src/commands/utility/settings/accessModule.ts
@@ -1,0 +1,102 @@
+import type { SettingsCategoryModule, SettingsAction } from './types.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { resolveTarget } from '../../../util/resolveTarget.js';
+import { writeSettings } from '../../../util/settingsStore.js';
+
+const ACTIONS: SettingsAction[] = [
+	{ name: 'View', value: 'view' },
+	{ name: 'Add', value: 'add' },
+	{ name: 'Remove', value: 'remove' },
+];
+
+const ALLOWED_ACTIONS = ['view', 'add', 'remove'];
+
+export const accessModule: SettingsCategoryModule = {
+	name: 'Access Permissions',
+	value: 'access',
+	actions: ACTIONS,
+
+	isActionAllowed(action: string): boolean {
+		return ALLOWED_ACTIONS.includes(action);
+	},
+
+	async execute(
+		interaction: ChatInputCommandInteraction,
+		action: string,
+		target: string | null,
+		settings: any,
+	): Promise<{ settings: any; reply: string }> {
+		if (!this.isActionAllowed(action)) {
+			return {
+				settings,
+				reply: 'Access permissions only support **add**, **remove**, and **view** actions.',
+			};
+		}
+
+		if (['add', 'remove'].includes(action) && !target) {
+			return {
+				settings,
+				reply: 'Target is required for access permission changes.',
+			};
+		}
+
+		const updatedSettings = { ...settings };
+		updatedSettings.access = updatedSettings.access ?? [];
+
+		if (action === 'add') {
+			const resolved = await resolveTarget(interaction.guild, target!);
+			const display =
+				resolved.kind === 'member'
+					? `${resolved.member.user.tag}`
+					: resolved.kind === 'role'
+						? `@${resolved.role.name}`
+						: target;
+
+			if (!updatedSettings.access.includes(target!)) {
+				updatedSettings.access.push(target!);
+				await writeSettings(updatedSettings);
+				return {
+					settings: updatedSettings,
+					reply: `Added ${display} to access list.`,
+				};
+			} else {
+				return {
+					settings,
+					reply: `${display} is already in the access list.`,
+				};
+			}
+		} else if (action === 'remove') {
+			const resolved = await resolveTarget(interaction.guild, target!);
+			const display =
+				resolved.kind === 'member'
+					? `${resolved.member.user.tag}`
+					: resolved.kind === 'role'
+						? `@${resolved.role.name}`
+						: target;
+
+			const idx = updatedSettings.access.indexOf(target!);
+			if (idx !== -1) {
+				updatedSettings.access.splice(idx, 1);
+				await writeSettings(updatedSettings);
+				return {
+					settings: updatedSettings,
+					reply: `Removed ${display} from access list.`,
+				};
+			} else {
+				return {
+					settings,
+					reply: `${display} was not found in the access list.`,
+				};
+			}
+		} else if (action === 'view') {
+			const list = updatedSettings.access ?? [];
+			const reply = list.length === 0 ? 'Access list is empty.' : `Access list:\n${list.join('\n')}`;
+			return {
+				settings,
+				reply,
+			};
+		}
+
+		return { settings, reply: 'Unknown action.' };
+	},
+};

--- a/src/commands/utility/settings/index.ts
+++ b/src/commands/utility/settings/index.ts
@@ -1,0 +1,4 @@
+export * from './types.js';
+export * from './registry.js';
+export { accessModule } from './accessModule.js';
+export { promptModule } from './promptModule.js';

--- a/src/commands/utility/settings/promptModule.ts
+++ b/src/commands/utility/settings/promptModule.ts
@@ -1,0 +1,66 @@
+import type { SettingsCategoryModule, SettingsAction } from './types.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { writeSettings } from '../../../util/settingsStore.js';
+
+const ACTIONS: SettingsAction[] = [
+	{ name: 'View', value: 'view' },
+	{ name: 'Set', value: 'set' },
+	{ name: 'Reset', value: 'reset' },
+];
+
+const ALLOWED_ACTIONS = ['view', 'set', 'reset'];
+
+export const promptModule: SettingsCategoryModule = {
+	name: 'Bot Prompt',
+	value: 'prompt',
+	actions: ACTIONS,
+
+	isActionAllowed(action: string): boolean {
+		return ALLOWED_ACTIONS.includes(action);
+	},
+
+	async execute(
+		_interaction: ChatInputCommandInteraction,
+		action: string,
+		target: string | null,
+		settings: any,
+	): Promise<{ settings: any; reply: string }> {
+		if (!this.isActionAllowed(action)) {
+			return {
+				settings,
+				reply: 'Bot prompt only supports **set**, **reset**, and **view** actions.',
+			};
+		}
+
+		const updatedSettings = { ...settings };
+
+		if (action === 'set') {
+			if (!target) {
+				return {
+					settings,
+					reply: 'Value is required when setting the prompt.',
+				};
+			}
+			updatedSettings.prompt = target;
+			await writeSettings(updatedSettings);
+			return {
+				settings: updatedSettings,
+				reply: `Bot prompt set to: "${target}"`,
+			};
+		} else if (action === 'reset') {
+			delete updatedSettings.prompt;
+			await writeSettings(updatedSettings);
+			return {
+				settings: updatedSettings,
+				reply: 'Bot prompt reset to default.',
+			};
+		} else if (action === 'view') {
+			return {
+				settings,
+				reply: `Current prompt: ${settings.prompt ?? '*not set*'}`,
+			};
+		}
+
+		return { settings, reply: 'Unknown action.' };
+	},
+};

--- a/src/commands/utility/settings/registry.ts
+++ b/src/commands/utility/settings/registry.ts
@@ -1,0 +1,41 @@
+import type { SettingsModuleRegistry, SettingsCategoryModule, SettingsAction } from './types.js';
+import { accessModule } from './accessModule.js';
+import { promptModule } from './promptModule.js';
+
+export const settingsRegistry: SettingsModuleRegistry = {
+	access: accessModule,
+	prompt: promptModule,
+};
+
+export function getAllCategories(): Array<{ name: string; value: string }> {
+	return Object.values(settingsRegistry).map((module) => ({
+		name: module.name,
+		value: module.value,
+	}));
+}
+
+export function getAllActions(): SettingsAction[] {
+	const actionMap = new Map<string, SettingsAction>();
+
+	Object.values(settingsRegistry).forEach((module) => {
+		module.actions.forEach((action) => {
+			actionMap.set(action.value, action);
+		});
+	});
+
+	return Array.from(actionMap.values());
+}
+
+export function getActionsForCategory(categoryValue: string): SettingsAction[] {
+	const module = settingsRegistry[categoryValue];
+	return module ? module.actions : [];
+}
+
+export function getModule(categoryValue: string): SettingsCategoryModule | undefined {
+	return settingsRegistry[categoryValue];
+}
+
+export function isActionAllowedForCategory(categoryValue: string, action: string): boolean {
+	const module = settingsRegistry[categoryValue];
+	return module ? module.isActionAllowed(action) : false;
+}

--- a/src/commands/utility/settings/types.ts
+++ b/src/commands/utility/settings/types.ts
@@ -1,0 +1,27 @@
+import type { ChatInputCommandInteraction } from 'discord.js';
+
+export interface SettingsAction {
+	name: string;
+	value: string;
+}
+
+export interface SettingsCategoryModule {
+	name: string;
+
+	value: string;
+
+	actions: SettingsAction[];
+
+	execute(
+		interaction: ChatInputCommandInteraction,
+		action: string,
+		target: string | null,
+		settings: any,
+	): Promise<{ settings: any; reply: string }>;
+
+	isActionAllowed(action: string): boolean;
+}
+
+export interface SettingsModuleRegistry {
+	[key: string]: SettingsCategoryModule;
+}

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,6 +1,7 @@
 import { URL } from 'node:url';
 import { Events } from 'discord.js';
 import { loadCommands } from '../util/loaders.js';
+import { handleSettingsAutocomplete } from './utility/settingsAutocomplete.js';
 import type { Event } from './index.js';
 
 const commands = await loadCommands(new URL('../commands/', import.meta.url));
@@ -8,7 +9,14 @@ const commands = await loadCommands(new URL('../commands/', import.meta.url));
 export default {
 	name: Events.InteractionCreate,
 	async execute(interaction) {
-		if (interaction.isCommand()) {
+		if (interaction.isAutocomplete()) {
+			if (interaction.commandName === 'settings') {
+				await handleSettingsAutocomplete(interaction);
+				return;
+			}
+		}
+
+		if (interaction.isChatInputCommand()) {
 			const command = commands.get(interaction.commandName);
 
 			if (!command) {

--- a/src/events/utility/settingsAutocomplete.ts
+++ b/src/events/utility/settingsAutocomplete.ts
@@ -1,0 +1,34 @@
+import type { AutocompleteInteraction } from 'discord.js';
+import { encodeChoiceValue, decodeChoiceValue } from '../../util/choiceEncoding.js';
+
+export async function handleSettingsAutocomplete(interaction: AutocompleteInteraction) {
+	const focused = interaction.options.getFocused(true);
+
+	if (focused.name === 'action') {
+		const rawCategory = interaction.options.getString('category');
+		const category = rawCategory ? decodeChoiceValue(rawCategory) : undefined;
+
+		const allActions = [
+			{ name: 'View', value: 'view' },
+			{ name: 'Add', value: 'add' },
+			{ name: 'Remove', value: 'remove' },
+			{ name: 'Set', value: 'set' },
+			{ name: 'Reset', value: 'reset' },
+		];
+
+		let allowed = allActions;
+		if (category === 'access') {
+			allowed = allActions.filter((a) => ['view', 'add', 'remove'].includes(a.value));
+		} else if (category === 'prompt') {
+			allowed = allActions.filter((a) => ['view', 'set', 'reset'].includes(a.value));
+		}
+
+		const input = String(focused.value ?? '').toLowerCase();
+		const suggestions = allowed
+			.filter((a) => a.name.toLowerCase().includes(input) || a.value.toLowerCase().includes(input))
+			.slice(0, 25)
+			.map((a) => ({ name: a.name, value: encodeChoiceValue(a.value) }));
+
+		await interaction.respond(suggestions);
+	}
+}

--- a/src/events/utility/settingsAutocomplete.ts
+++ b/src/events/utility/settingsAutocomplete.ts
@@ -1,5 +1,6 @@
 import type { AutocompleteInteraction } from 'discord.js';
 import { encodeChoiceValue, decodeChoiceValue } from '../../util/choiceEncoding.js';
+import { getAllActions, getActionsForCategory } from '../../commands/utility/settings/registry.js';
 
 export async function handleSettingsAutocomplete(interaction: AutocompleteInteraction) {
 	const focused = interaction.options.getFocused(true);
@@ -8,19 +9,11 @@ export async function handleSettingsAutocomplete(interaction: AutocompleteIntera
 		const rawCategory = interaction.options.getString('category');
 		const category = rawCategory ? decodeChoiceValue(rawCategory) : undefined;
 
-		const allActions = [
-			{ name: 'View', value: 'view' },
-			{ name: 'Add', value: 'add' },
-			{ name: 'Remove', value: 'remove' },
-			{ name: 'Set', value: 'set' },
-			{ name: 'Reset', value: 'reset' },
-		];
+		const allActions = getAllActions();
 
 		let allowed = allActions;
-		if (category === 'access') {
-			allowed = allActions.filter((a) => ['view', 'add', 'remove'].includes(a.value));
-		} else if (category === 'prompt') {
-			allowed = allActions.filter((a) => ['view', 'set', 'reset'].includes(a.value));
+		if (category) {
+			allowed = getActionsForCategory(category);
 		}
 
 		const input = String(focused.value ?? '').toLowerCase();

--- a/src/util/choiceEncoding.ts
+++ b/src/util/choiceEncoding.ts
@@ -1,0 +1,9 @@
+export function encodeChoiceValue(v: string) {
+	if (v.startsWith('=')) return `__EQ__${v.slice(1)}`;
+	return v;
+}
+
+export function decodeChoiceValue(v: string) {
+	if (v.startsWith('__EQ__')) return `=${v.slice('__EQ__'.length)}`;
+	return v;
+}

--- a/src/util/resolveTarget.ts
+++ b/src/util/resolveTarget.ts
@@ -1,0 +1,47 @@
+import type { GuildMember, Role, Guild } from 'discord.js';
+
+export type ResolvedTarget =
+	| { kind: 'member'; member: GuildMember }
+	| { kind: 'role'; role: Role }
+	| { kind: 'raw'; value: string };
+
+export async function resolveTarget(guild: Guild | null | undefined, raw: string): Promise<ResolvedTarget> {
+	raw = raw.trim();
+
+	// user mention <@123> or <@!123>
+	const mentionUser = raw.match(/^<@!?(\d+)>$/);
+	if (mentionUser && guild) {
+		const id = mentionUser[1];
+		const member = await guild.members.fetch(id).catch(() => null);
+		if (member) return { kind: 'member', member };
+	}
+
+	// role mention <@&123>
+	const mentionRole = raw.match(/^<@&(\d+)>$/);
+	if (mentionRole && guild) {
+		const id = mentionRole[1];
+		const role = guild.roles.cache.get(id) ?? (await guild.roles.fetch(id).catch(() => null));
+		if (role) return { kind: 'role', role };
+	}
+
+	// plain id (member or role)
+	if (/^\d{17,19}$/.test(raw) && guild) {
+		const [member, role] = await Promise.all([
+			guild.members.fetch(raw).catch(() => null),
+			guild.roles.fetch(raw).catch(() => null),
+		]);
+		if (member) return { kind: 'member', member };
+		if (role) return { kind: 'role', role };
+	}
+
+	// exact username or role name
+	if (guild) {
+		const byName = guild.members.cache.find((m) => m.user.username.toLowerCase() === raw.toLowerCase());
+		if (byName) return { kind: 'member', member: byName };
+		const byRole = guild.roles.cache.find((r) => r.name.toLowerCase() === raw.toLowerCase());
+		if (byRole) return { kind: 'role', role: byRole };
+	}
+
+	// fallback to raw string
+	return { kind: 'raw', value: raw };
+}

--- a/src/util/settingsStore.ts
+++ b/src/util/settingsStore.ts
@@ -1,0 +1,45 @@
+import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+
+export type StoredSettings = {
+	prompt?: string;
+	access?: string[];
+};
+
+const filePath = resolve(process.cwd(), 'data', 'settings.json');
+
+async function ensureDirAndFile() {
+	const dir = dirname(filePath);
+
+	try {
+		await mkdir(dir, { recursive: true });
+	} catch (e) {
+		// ignore
+	}
+
+	try {
+		await access(filePath);
+	} catch (e) {
+		await writeFile(filePath, JSON.stringify({}, null, 2), 'utf8');
+	}
+}
+
+export async function readSettings(): Promise<StoredSettings> {
+	try {
+		const raw = await readFile(filePath, 'utf8');
+		return JSON.parse(raw) as StoredSettings;
+	} catch (e) {
+		return {};
+	}
+}
+
+export async function writeSettings(settings: StoredSettings): Promise<void> {
+	try {
+		await mkdir(dirname(filePath), { recursive: true });
+	} catch (e) {
+		// ignore
+	}
+	await writeFile(filePath, JSON.stringify(settings, null, 2), 'utf8');
+}
+
+ensureDirAndFile().catch(() => undefined);


### PR DESCRIPTION
- .gitignore:
  - add 'data' folder to ignored files

- src/commands/index.ts:
  - replace CommandInteraction with ChatInputCommandInteraction for type safety

- src/commands/utility/settings.ts:
  - refactor settings command to use modular category/action input
  - delegate logic to settings modules for access and prompt
  - implement persistent settings storage and target resolution

- src/commands/utility/settings/:
  - add accessModule.ts: manage access permissions (add, remove, view)
  - add promptModule.ts: manage bot prompt (set, reset, view)
  - add registry.ts: registry and helpers for settings modules/actions/categories
  - add types.ts: define settings module and registry interfaces
  - add index.ts: export types, modules, registry

- src/events/interactionCreate.ts:
  - handle autocomplete interactions for settings command
  - update command interaction handling for chat input

- src/events/utility/settingsAutocomplete.ts:
  - add autocomplete handler for dynamic action suggestions

- src/util/choiceEncoding.ts:
  - add encode/decode utilities for choice values

- src/util/resolveTarget.ts:
  - add helper to resolve user/role from various formats

- src/util/settingsStore.ts:
  - add utility for persistent settings read/write
  - ensure directory and file exist on startup