### PR TITLE
fix(settings): improve error handling and replies

### DIFF
--- a/src/commands/utility/settings.ts
+++ b/src/commands/utility/settings.ts
@@ -31,6 +31,8 @@ export default {
 		],
 	},
 	async execute(interaction) {
+		await interaction.deferReply();
+
 		const category = interaction.options.getString('category', true);
 		const action = interaction.options.getString('action', true);
 		const target = interaction.options.getString('target');
@@ -39,16 +41,23 @@ export default {
 		const module = getModule(category);
 
 		if (!module) {
-			await interaction.reply(`Unknown settings category: ${category}`);
+			await interaction.editReply(`Unknown settings category: ${category}`);
 			return;
 		}
 
 		try {
 			const result = await module.execute(interaction, action, target, settings);
-			await interaction.reply(result.reply);
+			await interaction.editReply(result.reply);
 		} catch (error) {
 			console.error('Settings command error:', error);
-			await interaction.reply('An error occurred while processing the settings command.');
+
+			if (!interaction.replied) {
+				try {
+					await interaction.editReply('An error occurred while processing the settings command.');
+				} catch (replyError) {
+					console.error('Error sending error reply:', replyError);
+				}
+			}
 		}
 	},
 } satisfies Command;

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -11,9 +11,13 @@ export default {
 	async execute(interaction) {
 		if (interaction.isAutocomplete()) {
 			if (interaction.commandName === 'settings') {
-				await handleSettingsAutocomplete(interaction);
-				return;
+				try {
+					await handleSettingsAutocomplete(interaction);
+				} catch (error) {
+					console.error('Error executing autocomplete for settings:', error);
+				}
 			}
+			return;
 		}
 
 		if (interaction.isChatInputCommand()) {
@@ -23,7 +27,19 @@ export default {
 				throw new Error(`Command '${interaction.commandName}' not found.`);
 			}
 
-			await command.execute(interaction);
+			try {
+				await command.execute(interaction);
+			} catch (error) {
+				console.error(`Error executing command ${interaction.commandName}:`, error);
+
+				if (!interaction.replied && !interaction.deferred) {
+					try {
+						await interaction.reply('An error occurred while executing this command.');
+					} catch (replyError) {
+						console.error('Error sending error reply:', replyError);
+					}
+				}
+			}
 		}
 	},
 } satisfies Event<Events.InteractionCreate>;

--- a/src/events/utility/settingsAutocomplete.ts
+++ b/src/events/utility/settingsAutocomplete.ts
@@ -3,25 +3,29 @@ import { encodeChoiceValue, decodeChoiceValue } from '../../util/choiceEncoding.
 import { getAllActions, getActionsForCategory } from '../../commands/utility/settings/registry.js';
 
 export async function handleSettingsAutocomplete(interaction: AutocompleteInteraction) {
-	const focused = interaction.options.getFocused(true);
+	try {
+		const focused = interaction.options.getFocused(true);
 
-	if (focused.name === 'action') {
-		const rawCategory = interaction.options.getString('category');
-		const category = rawCategory ? decodeChoiceValue(rawCategory) : undefined;
+		if (focused.name === 'action') {
+			const rawCategory = interaction.options.getString('category');
+			const category = rawCategory ? decodeChoiceValue(rawCategory) : undefined;
 
-		const allActions = getAllActions();
+			const allActions = getAllActions();
 
-		let allowed = allActions;
-		if (category) {
-			allowed = getActionsForCategory(category);
+			let allowed = allActions;
+			if (category) {
+				allowed = getActionsForCategory(category);
+			}
+
+			const input = String(focused.value ?? '').toLowerCase();
+			const suggestions = allowed
+				.filter((a) => a.name.toLowerCase().includes(input) || a.value.toLowerCase().includes(input))
+				.slice(0, 25)
+				.map((a) => ({ name: a.name, value: encodeChoiceValue(a.value) }));
+
+			await interaction.respond(suggestions);
 		}
-
-		const input = String(focused.value ?? '').toLowerCase();
-		const suggestions = allowed
-			.filter((a) => a.name.toLowerCase().includes(input) || a.value.toLowerCase().includes(input))
-			.slice(0, 25)
-			.map((a) => ({ name: a.name, value: encodeChoiceValue(a.value) }));
-
-		await interaction.respond(suggestions);
+	} catch (error) {
+		console.error('Error in settings autocomplete:', error);
 	}
 }


### PR DESCRIPTION
- src/commands/utility/settings.ts:
  - defer reply before processing command
  - use editReply instead of reply for responses
  - improve error handling for command execution and replies
- src/events/interactionCreate.ts:
  - wrap autocomplete and command execution in try/catch
  - add fallback error replies if not already replied or deferred
- src/events/utility/settingsAutocomplete.ts:
  - add try/catch for autocomplete logic
  - log errors for failed autocomplete