### PR TITLE
feat(events): add messageCreate handler and channel setting

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,0 +1,18 @@
+import { Events } from 'discord.js';
+import type { Event } from './index.js';
+import { readSettings } from '../util/settingsStore.js';
+
+export default {
+	name: Events.MessageCreate,
+	async execute(message) {
+		if (message.author.bot) return;
+
+		const settings = await readSettings();
+		if (settings.channel && message.channelId !== settings.channel) {
+			return;
+		}
+
+		console.log(`Message received from ${message.author.tag}: ${message.content}`);
+		// do something
+	},
+} satisfies Event<Events.MessageCreate>;

--- a/src/util/settingsStore.ts
+++ b/src/util/settingsStore.ts
@@ -4,6 +4,7 @@ import { resolve, dirname } from 'node:path';
 export type StoredSettings = {
 	prompt?: string;
 	access?: string[];
+	channel?: string;
 };
 
 const filePath = resolve(process.cwd(), 'data', 'settings.json');


### PR DESCRIPTION
- src/events/messageCreate.ts:
  - add message create event handler
  - filter out bot messages
  - restrict messages to a configurable channel
  - log message details to console
- src/util/settingsStore.ts:
  - add optional channel property to settings type