### PR TITLE
refactor(settings): modularize action handlers and unify reply logic

### DIFF
--- a/src/commands/utility/settings/channelModule.ts
+++ b/src/commands/utility/settings/channelModule.ts
@@ -10,6 +10,84 @@ const ACTIONS: SettingsAction[] = [
 
 const ALLOWED_ACTIONS = ['view', 'set', 'reset'];
 
+function createResult(settings: any, reply: string): { settings: any; reply: string } {
+	return { settings, reply };
+}
+
+function extractChannelId(target: string): string {
+	return target.replace(/[<#>]/g, '');
+}
+
+async function validateAndFetchChannel(
+	interaction: ChatInputCommandInteraction,
+	channelId: string,
+): Promise<{ channel: Channel | null; error: string | null }> {
+	try {
+		const channel = await interaction.client.channels.fetch(channelId);
+
+		if (!channel) {
+			return { channel: null, error: 'Channel not found or the bot cannot access it.' };
+		}
+
+		if (!channel.isTextBased()) {
+			return { channel: null, error: 'The specified channel must be a text channel.' };
+		}
+
+		return { channel, error: null };
+	} catch (error) {
+		return { channel: null, error: 'Invalid channel ID or the bot cannot access that channel.' };
+	}
+}
+
+async function handleSetAction(
+	interaction: ChatInputCommandInteraction,
+	target: string | null,
+	updatedSettings: any,
+): Promise<{ settings: any; reply: string }> {
+	if (!target) {
+		return createResult(updatedSettings, 'Channel ID or mention is required when setting the channel.');
+	}
+
+	const channelId = extractChannelId(target);
+	const { error } = await validateAndFetchChannel(interaction, channelId);
+
+	if (error) {
+		return createResult(updatedSettings, error);
+	}
+
+	updatedSettings.channel = channelId;
+	await writeSettings(updatedSettings);
+	return createResult(updatedSettings, `Channel set to <#${channelId}>`);
+}
+
+async function handleResetAction(updatedSettings: any): Promise<{ settings: any; reply: string }> {
+	delete updatedSettings.channel;
+	await writeSettings(updatedSettings);
+	return createResult(updatedSettings, 'Channel reset. Bot will now listen to all channels where it has access.');
+}
+
+async function handleViewAction(
+	interaction: ChatInputCommandInteraction,
+	settings: any,
+): Promise<{ settings: any; reply: string }> {
+	const channelId = settings.channel;
+
+	if (!channelId) {
+		return createResult(settings, 'Channel: *not set* (listening to all accessible channels)');
+	}
+
+	try {
+		const channel = await interaction.client.channels.fetch(channelId);
+		if (channel) {
+			return createResult(settings, `Current channel: <#${channelId}>`);
+		}
+	} catch (error) {
+		return createResult(settings, `Channel is set to \`${channelId}\` but the channel is no longer accessible.`);
+	}
+
+	return createResult(settings, `Channel: \`${channelId}\` (channel may no longer exist)`);
+}
+
 export const channelModule: SettingsCategoryModule = {
 	name: 'Channel',
 	value: 'channel',
@@ -26,91 +104,20 @@ export const channelModule: SettingsCategoryModule = {
 		settings: any,
 	): Promise<{ settings: any; reply: string }> {
 		if (!this.isActionAllowed(action)) {
-			return {
-				settings,
-				reply: 'Channel only supports **set**, **reset**, and **view** actions.',
-			};
+			return createResult(settings, 'Channel only supports **set**, **reset**, and **view** actions.');
 		}
 
 		const updatedSettings = { ...settings };
 
-		if (action === 'set') {
-			if (!target) {
-				return {
-					settings,
-					reply: 'Channel ID or mention is required when setting the channel.',
-				};
-			}
-
-			const channelId = target.replace(/[<#>]/g, '');
-
-			let channel: Channel | null = null;
-			try {
-				channel = await interaction.client.channels.fetch(channelId);
-			} catch (error) {
-				return {
-					settings,
-					reply: 'Invalid channel ID or the bot cannot access that channel.',
-				};
-			}
-
-			if (!channel) {
-				return {
-					settings,
-					reply: 'Channel not found or the bot cannot access it.',
-				};
-			}
-
-			if (!channel.isTextBased()) {
-				return {
-					settings,
-					reply: 'The specified channel must be a text channel.',
-				};
-			}
-
-			updatedSettings.channel = channelId;
-			await writeSettings(updatedSettings);
-			return {
-				settings: updatedSettings,
-				reply: `Channel set to <#${channelId}>`,
-			};
-		} else if (action === 'reset') {
-			delete updatedSettings.channel;
-			await writeSettings(updatedSettings);
-			return {
-				settings: updatedSettings,
-				reply: 'Channel reset. Bot will now listen to all channels where it has access.',
-			};
-		} else if (action === 'view') {
-			const channelId = settings.channel;
-			if (!channelId) {
-				return {
-					settings,
-					reply: 'Channel: *not set* (listening to all accessible channels)',
-				};
-			}
-
-			try {
-				const channel = await interaction.client.channels.fetch(channelId);
-				if (channel) {
-					return {
-						settings,
-						reply: `Current channel: <#${channelId}>`,
-					};
-				}
-			} catch (error) {
-				return {
-					settings,
-					reply: `Channel is set to \`${channelId}\` but the channel is no longer accessible.`,
-				};
-			}
-
-			return {
-				settings,
-				reply: `Channel: \`${channelId}\` (channel may no longer exist)`,
-			};
+		switch (action) {
+			case 'set':
+				return handleSetAction(interaction, target, updatedSettings);
+			case 'reset':
+				return handleResetAction(updatedSettings);
+			case 'view':
+				return handleViewAction(interaction, settings);
+			default:
+				return createResult(settings, 'Unknown action.');
 		}
-
-		return { settings, reply: 'Unknown action.' };
 	},
 };

--- a/src/discord/operations.ts
+++ b/src/discord/operations.ts
@@ -48,6 +48,19 @@ import type {
 	DeleteWebhookData,
 } from '../types/index.js';
 
+function getChannelTypeDisplayName(channelType: number): string {
+	switch (channelType) {
+		case 0:
+			return 'text';
+		case 2:
+			return 'voice';
+		case 4:
+			return 'category';
+		default:
+			return 'unknown';
+	}
+}
+
 export async function findServer(serverId?: string): Promise<Guild> {
 	if (!serverId) {
 		if (discordClient.guilds.cache.size === 1) {
@@ -231,9 +244,8 @@ export async function deleteAllChannels({
 
 			try {
 				await channel.delete();
-				results.push(
-					`Deleted ${channel.type === 0 ? 'text' : channel.type === 2 ? 'voice' : channel.type === 4 ? 'category' : 'unknown'} channel "${channel.name}"`,
-				);
+				const channelTypeName = getChannelTypeDisplayName(channel.type);
+				results.push(`Deleted ${channelTypeName} channel "${channel.name}"`);
 				deletedCount++;
 			} catch (error) {
 				results.push(`Failed to delete "${channel.name}": ${error}`);
@@ -606,7 +618,11 @@ export async function setChannelPermissions({
 			return `Role "${roleName}" not found in ${guild.name}.`;
 		}
 
-		return `Found channel "${channel.name}" and role "${role.name}". Permission management requires manual configuration in Discord for security reasons. Would change:\n${allow.length > 0 ? `Allow: ${allow.join(', ')}\n` : ''}${deny.length > 0 ? `Deny: ${deny.join(', ')}` : 'No changes specified'}`;
+		const allowMessage = allow.length > 0 ? `Allow: ${allow.join(', ')}\n` : '';
+		const denyMessage = deny.length > 0 ? `Deny: ${deny.join(', ')}` : 'No changes specified';
+		const changesMessage = allowMessage + denyMessage;
+
+		return `Found channel "${channel.name}" and role "${role.name}". Permission management requires manual configuration in Discord for security reasons. Would change:\n${changesMessage}`;
 	} catch (error) {
 		throw new Error(`Failed to set channel permissions: ${error}`);
 	}

--- a/src/handlers/messageHandler.ts
+++ b/src/handlers/messageHandler.ts
@@ -162,6 +162,128 @@ const functionHandlers: Record<string, (args: any) => Promise<any>> = {
 	},
 };
 
+function getChannelName(message: Message): string {
+	return message.channel?.isTextBased() && 'name' in message.channel && message.channel.name
+		? message.channel.name
+		: message.channelId;
+}
+
+async function checkMessageAndChannelAccess(message: Message): Promise<{
+	messageExists: boolean;
+	channelExists: boolean;
+	targetChannel: any;
+}> {
+	let messageExists = true;
+	let channelExists = true;
+	let targetChannel = message.channel;
+
+	try {
+		await message.fetch();
+	} catch (error) {
+		messageExists = false;
+		console.log('Original message no longer exists, will send regular message');
+	}
+
+	try {
+		if (message.channel?.isTextBased() && 'id' in message.channel) {
+			await discordClient.channels.fetch(message.channel.id);
+		}
+	} catch (error) {
+		channelExists = false;
+		console.log('Original channel no longer exists, finding suitable channel');
+		if (message.guildId) {
+			const suitableChannel = await findSuitableChannel(message.guildId);
+			if (suitableChannel) {
+				targetChannel = suitableChannel;
+			} else {
+				console.log('No suitable channel found for response');
+				return { messageExists, channelExists, targetChannel: null };
+			}
+		}
+	}
+
+	return { messageExists, channelExists, targetChannel };
+}
+
+async function sendResponseMessage(
+	message: Message,
+	responseText: string,
+	messageExists: boolean,
+	channelExists: boolean,
+	targetChannel: any,
+): Promise<void> {
+	if (messageExists && channelExists && targetChannel === message.channel) {
+		try {
+			await message.reply(responseText);
+		} catch (error) {
+			console.log('Failed to reply to message, sending regular message instead:', error);
+			if (targetChannel?.isTextBased() && 'send' in targetChannel) {
+				await targetChannel.send(responseText);
+			}
+		}
+	} else {
+		if (targetChannel?.isTextBased() && 'send' in targetChannel) {
+			await targetChannel.send(responseText);
+		}
+	}
+}
+
+function buildConversationContext(
+	contextualMessage: string,
+	conversationHistory: ConversationMessage[],
+): Array<{
+	role: 'user' | 'model';
+	parts: Array<{ text: string }>;
+}> {
+	const aiConfig = {
+		maxRecentMessages: 10,
+		functionCallPrefix: 'Function ',
+		messages: {
+			previousContext: 'Previous conversation context:',
+			functionResults: 'Recent function call results (you can reference this data in your responses):',
+			functionResultItem: '{index}. {text}',
+		},
+	};
+
+	let conversation: Array<{
+		role: 'user' | 'model';
+		parts: Array<{ text: string }>;
+	}> = [
+		{
+			role: 'user',
+			parts: [{ text: contextualMessage }],
+		},
+	];
+
+	const recentMessages = conversationHistory.slice(-aiConfig.maxRecentMessages);
+	if (recentMessages.length > 0) {
+		const functionResultsInHistory = recentMessages.filter(
+			(msg) => msg.role === 'user' && msg.parts[0]?.text?.startsWith(aiConfig.functionCallPrefix),
+		);
+
+		let contextMessage = aiConfig.messages.previousContext;
+		if (functionResultsInHistory.length > 0) {
+			contextMessage += '\n\n' + aiConfig.messages.functionResults;
+			functionResultsInHistory.forEach((result, index) => {
+				contextMessage += `\n${index + 1}. ${result.parts[0].text}`;
+			});
+		}
+
+		conversation.unshift(
+			{
+				role: 'user',
+				parts: [{ text: contextMessage }],
+			},
+			...recentMessages.map((msg) => ({
+				role: msg.role,
+				parts: msg.parts,
+			})),
+		);
+	}
+
+	return conversation;
+}
+
 export async function handleMessage(message: Message, aiClient: GoogleGenAI): Promise<void> {
 	if (message.author.bot) return;
 
@@ -176,54 +298,15 @@ export async function handleMessage(message: Message, aiClient: GoogleGenAI): Pr
 	try {
 		const tools = createAITools();
 		const config = createAIConfig(getCachedSettings(), [tools]);
-
 		const modelName = 'gemini-2.5-flash-lite';
 
-		const channelName =
-			message.channel && message.channel.isTextBased() && 'name' in message.channel
-				? message.channel.name
-				: message.channelId;
-
+		const channelName = getChannelName(message);
 		const contextualMessage = `Current channel: ${channelName} (ID: ${message.channelId})\nUser message: ${userMessage}`;
 
 		const previousHistory = await getConversationHistory(message.channelId);
 		const conversationHistory = previousHistory?.messages || [];
 
-		let conversation: Array<{
-			role: 'user' | 'model';
-			parts: Array<{ text: string }>;
-		}> = [
-			{
-				role: 'user',
-				parts: [{ text: contextualMessage }],
-			},
-		];
-
-		const recentMessages = conversationHistory.slice(-10);
-		if (recentMessages.length > 0) {
-			const functionResultsInHistory = recentMessages.filter(
-				(msg) => msg.role === 'user' && msg.parts[0]?.text?.startsWith('Function '),
-			);
-
-			let contextMessage = 'Previous conversation context:';
-			if (functionResultsInHistory.length > 0) {
-				contextMessage += '\n\nRecent function call results (you can reference this data in your responses):';
-				functionResultsInHistory.forEach((result, index) => {
-					contextMessage += `\n${index + 1}. ${result.parts[0].text}`;
-				});
-			}
-
-			conversation.unshift(
-				{
-					role: 'user',
-					parts: [{ text: contextMessage }],
-				},
-				...recentMessages.map((msg) => ({
-					role: msg.role,
-					parts: msg.parts,
-				})),
-			);
-		}
+		const conversation = buildConversationContext(contextualMessage, conversationHistory);
 
 		let responseText = '';
 		let hasFunctionCalls = false;
@@ -242,7 +325,7 @@ export async function handleMessage(message: Message, aiClient: GoogleGenAI): Pr
 
 			let functionResults: Array<{ name: string; result: any }> = [];
 
-			if (response.functionCalls && response.functionCalls.length > 0) {
+			if (response.functionCalls?.length) {
 				hasFunctionCalls = true;
 				for (const call of response.functionCalls) {
 					try {
@@ -257,57 +340,37 @@ export async function handleMessage(message: Message, aiClient: GoogleGenAI): Pr
 							console.log('Function call result:', result);
 						} else {
 							console.warn(`Unknown function: ${call.name}`);
-							functionResults.push({
-								name: call.name,
-								result: { error: `Unknown function: ${call.name}` },
-							});
-							allFunctionResults.push({
-								name: call.name,
-								result: { error: `Unknown function: ${call.name}` },
-							});
+							const errorResult = { error: `Unknown function: ${call.name}` };
+							functionResults.push({ name: call.name, result: errorResult });
+							allFunctionResults.push({ name: call.name, result: errorResult });
 						}
 					} catch (error) {
 						console.error('Call error:', error);
 						if (call.name) {
-							functionResults.push({
-								name: call.name,
-								result: {
-									error: error instanceof Error ? error.message : 'Unknown error',
-								},
-							});
-							allFunctionResults.push({
-								name: call.name,
-								result: {
-									error: error instanceof Error ? error.message : 'Unknown error',
-								},
-							});
+							const errorResult = {
+								error: error instanceof Error ? error.message : 'Unknown error',
+							};
+							functionResults.push({ name: call.name, result: errorResult });
+							allFunctionResults.push({ name: call.name, result: errorResult });
 						}
 					}
 				}
 
 				conversation.push({
 					role: 'model',
-					parts: [
-						{
-							text: 'I executed the requested functions.',
-						},
-					],
+					parts: [{ text: 'I executed the requested functions.' }],
 				});
 
 				for (const funcResult of functionResults) {
 					conversation.push({
 						role: 'user',
-						parts: [
-							{
-								text: `Function ${funcResult.name} returned: ${JSON.stringify(funcResult.result)}`,
-							},
-						],
+						parts: [{ text: `Function ${funcResult.name} returned: ${JSON.stringify(funcResult.result)}` }],
 					});
 				}
 			} else {
 				if (response.candidates) {
 					for (const candidate of response.candidates) {
-						if (candidate.content && candidate.content.parts) {
+						if (candidate.content?.parts) {
 							for (const part of candidate.content.parts) {
 								if (part.text && typeof part.text === 'string') {
 									responseText += part.text;
@@ -341,20 +404,11 @@ export async function handleMessage(message: Message, aiClient: GoogleGenAI): Pr
 			timestamp: Date.now(),
 		};
 
-		const functionResultEntries: ConversationMessage[] = [];
-		if (allFunctionResults.length > 0) {
-			for (const funcResult of allFunctionResults) {
-				functionResultEntries.push({
-					role: 'user',
-					parts: [
-						{
-							text: `Function ${funcResult.name} returned: ${JSON.stringify(funcResult.result)}`,
-						},
-					],
-					timestamp: Date.now(),
-				});
-			}
-		}
+		const functionResultEntries: ConversationMessage[] = allFunctionResults.map((funcResult) => ({
+			role: 'user' as const,
+			parts: [{ text: `Function ${funcResult.name} returned: ${JSON.stringify(funcResult.result)}` }],
+			timestamp: Date.now(),
+		}));
 
 		await addMessageToConversation(message.channelId, userMessageEntry);
 
@@ -364,146 +418,25 @@ export async function handleMessage(message: Message, aiClient: GoogleGenAI): Pr
 
 		await addMessageToConversation(message.channelId, botResponseEntry);
 
+		const { messageExists, channelExists, targetChannel } = await checkMessageAndChannelAccess(message);
+
+		if (!targetChannel) return;
+
 		if (responseText.trim()) {
-			let messageExists = true;
-			let channelExists = true;
-			let targetChannel = message.channel;
-
-			try {
-				await message.fetch();
-			} catch (error) {
-				messageExists = false;
-				console.log('Original message no longer exists, will send regular message');
-			}
-
-			try {
-				if (message.channel && message.channel.isTextBased() && 'id' in message.channel) {
-					await discordClient.channels.fetch(message.channel.id);
-				}
-			} catch (error) {
-				channelExists = false;
-				console.log('Original channel no longer exists, finding suitable channel');
-				if (message.guildId) {
-					const suitableChannel = await findSuitableChannel(message.guildId);
-					if (suitableChannel) {
-						targetChannel = suitableChannel;
-					} else {
-						console.log('No suitable channel found for response');
-						return;
-					}
-				}
-			}
-
-			if (messageExists && channelExists && targetChannel === message.channel) {
-				try {
-					await message.reply(responseText);
-				} catch (error) {
-					console.log('Failed to reply to message, sending regular message instead:', error);
-					if (targetChannel && targetChannel.isTextBased() && 'send' in targetChannel) {
-						await targetChannel.send(responseText);
-					}
-				}
-			} else {
-				if (targetChannel && targetChannel.isTextBased() && 'send' in targetChannel) {
-					await targetChannel.send(responseText);
-				}
-			}
+			await sendResponseMessage(message, responseText, messageExists, channelExists, targetChannel);
 		} else {
 			console.log('No response text found, sending debug info');
-			let messageExists = true;
-			let channelExists = true;
-			let targetChannel = message.channel;
-
-			try {
-				await message.fetch();
-			} catch (error) {
-				messageExists = false;
-				console.log('Original message no longer exists, will send regular message');
-			}
-
-			try {
-				if (message.channel && message.channel.isTextBased() && 'id' in message.channel) {
-					await discordClient.channels.fetch(message.channel.id);
-				}
-			} catch (error) {
-				channelExists = false;
-				console.log('Original channel no longer exists, finding suitable channel');
-				if (message.guildId) {
-					const suitableChannel = await findSuitableChannel(message.guildId);
-					if (suitableChannel) {
-						targetChannel = suitableChannel;
-					} else {
-						console.log('No suitable channel found for response');
-						return;
-					}
-				}
-			}
-
-			if (messageExists && channelExists && targetChannel === message.channel) {
-				try {
-					await message.reply(
-						"I received your message but couldn't generate a response. Please check the logs for details.",
-					);
-				} catch (error) {
-					console.log('Failed to reply to message, sending regular message instead:', error);
-					if (targetChannel && targetChannel.isTextBased() && 'send' in targetChannel) {
-						await targetChannel.send(
-							"I received your message but couldn't generate a response. Please check the logs for details.",
-						);
-					}
-				}
-			} else {
-				if (targetChannel && targetChannel.isTextBased() && 'send' in targetChannel) {
-					await targetChannel.send(
-						"I received your message but couldn't generate a response. Please check the logs for details.",
-					);
-				}
-			}
+			const debugMessage =
+				"I received your message but couldn't generate a response. Please check the logs for details.";
+			await sendResponseMessage(message, debugMessage, messageExists, channelExists, targetChannel);
 		}
 	} catch (error) {
 		console.error('Error:', error);
-		let messageExists = true;
-		let channelExists = true;
-		let targetChannel = message.channel;
+		const { messageExists, channelExists, targetChannel } = await checkMessageAndChannelAccess(message);
 
-		try {
-			await message.fetch();
-		} catch (fetchError) {
-			messageExists = false;
-			console.log('Original message no longer exists during error handling');
-		}
-
-		try {
-			if (message.channel && message.channel.isTextBased() && 'id' in message.channel) {
-				await discordClient.channels.fetch(message.channel.id);
-			}
-		} catch (error) {
-			channelExists = false;
-			console.log('Original channel no longer exists during error handling, finding suitable channel');
-			if (message.guildId) {
-				const suitableChannel = await findSuitableChannel(message.guildId);
-				if (suitableChannel) {
-					targetChannel = suitableChannel;
-				} else {
-					console.log('No suitable channel found for error response');
-					return;
-				}
-			}
-		}
-
-		if (messageExists && channelExists && targetChannel === message.channel) {
-			try {
-				await message.reply('Sorry, I encountered an error processing your message.');
-			} catch (replyError) {
-				console.log('Failed to reply to message during error handling:', replyError);
-				if (targetChannel && targetChannel.isTextBased() && 'send' in targetChannel) {
-					await targetChannel.send('Sorry, I encountered an error processing your message.');
-				}
-			}
-		} else {
-			if (targetChannel && targetChannel.isTextBased() && 'send' in targetChannel) {
-				await targetChannel.send('Sorry, I encountered an error processing your message.');
-			}
+		if (targetChannel) {
+			const errorMessage = 'Sorry, I encountered an error processing your message.';
+			await sendResponseMessage(message, errorMessage, messageExists, channelExists, targetChannel);
 		}
 	}
 }


### PR DESCRIPTION
- src/commands/utility/settings/accessModule.ts:
  - extract action handlers for add, remove, and view operations
  - centralize reply formatting logic
  - add helper to display member/role names
  - improve target validation

- src/commands/utility/settings/channelModule.ts:
  - modularize set, reset, and view handlers
  - unify error and reply formatting
  - add channel validation and extraction helpers

- src/commands/utility/settings/promptModule.ts:
  - separate set, reset, and view operations into distinct functions
  - standardize result formatting

- src/discord/operations.ts:
  - extract channel type display logic into helper
  - refactor permission change messaging for clarity

- src/handlers/messageHandler.ts:
  - extract channel and message existence checks
  - centralize response sending logic
  - modularize conversation context building
  - simplify function call result handling